### PR TITLE
支持本地vllm部署模型，修复带 / 仓库的的gerrit api访问

### DIFF
--- a/src/main/java/com/googlesource/gerrit/plugins/chatgpt/client/HttpClientWithRetry.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/chatgpt/client/HttpClientWithRetry.java
@@ -19,6 +19,8 @@ public class HttpClientWithRetry {
     private final Retryer<HttpResponse<String>> retryer;
 
     private final HttpClient httpClient = HttpClient.newBuilder()
+            // Don't use default HttpClient.Version.HTTP_2 for some old inference servers
+            .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(Duration.ofMinutes(5))
             .build();
 

--- a/src/main/java/com/googlesource/gerrit/plugins/chatgpt/listener/EventListenerHandler.java
+++ b/src/main/java/com/googlesource/gerrit/plugins/chatgpt/listener/EventListenerHandler.java
@@ -35,7 +35,10 @@ public class EventListenerHandler {
     }
 
     public static String buildFullChangeId(Project.NameKey projectName, BranchNameKey branchName, Change.Key changeKey) {
-        return String.join("~", projectName.get(), branchName.shortName(), changeKey.get());
+        // project name need escape '/'. Otherwise, the full change id will be invalid.
+        // for example: test%2Fproject%2name~test-branch~I7a1f81560359a6688ae3acabe5e753158ddf832a
+        String projectNameEscaped = projectName.get().replace("/", "%2F");
+        return String.join("~", projectNameEscaped, branchName.shortName(), changeKey.get());
     }
 
     private void addShutdownHoot() {


### PR DESCRIPTION
- 支持本地vllm部署模型, vllm 推理服务目前不支持 http 2
- 修复带 / 仓库， 当仓库名为 groupname/projectname 时，会因为 / 导致调用 gerrit api 失败，增加转义